### PR TITLE
2xl format

### DIFF
--- a/src/components/home/HomeTitle.jsx
+++ b/src/components/home/HomeTitle.jsx
@@ -13,16 +13,16 @@ const HomeTitle = () => {
         alt="Background image 2"
         className="w-screen top-1/2 absolute"
       />
-      <div className="w-screen md:right-[7%] right-[10%] md:bottom-[30%] bottom-[12%] absolute flex flex-col items-end text-xs md:text-xl  2xl:text-4xl ">
+      <div className="w-screen md:right-[7%] right-[10%] md:bottom-[30%] bottom-[12%] absolute flex flex-col items-end text-xs md:text-xl 2xl:text-3xl ">
         <p className="italic font-thin">Presenting</p>
         <p className="italic font-bold">Laviathan 2024</p>
         <SlArrowDown className="m-3 mr-9 md:mr-8 md:text-2xl" />
       </div>
-      <div className="md:text-[80px]  text-[25px] left-[15%] absolute top-[28%]  ">
-        <p className="  2xl:text-8xl drop-shadow-lg shadow-black font-bold text-robosub-yellow translate-y-3 md:translate-y-6 relative ">
+      <div className="md:text-[80px] 2xl:text-[100px] text-[25px] left-[15%] absolute top-[28%]  ">
+        <p className="drop-shadow-lg shadow-black font-bold text-robosub-yellow translate-y-3 md:translate-y-6 relative ">
           UCR
         </p>
-        <p className=" 2xl:text-9xl 2xl:mt-9 font-bold">ROBOSUB</p>
+        <p className="font-bold">ROBOSUB</p>
       </div>
     </div>
   );

--- a/src/components/home/HomeTitle.jsx
+++ b/src/components/home/HomeTitle.jsx
@@ -6,23 +6,23 @@ import { SlArrowDown } from "react-icons/sl";
 
 const HomeTitle = () => {
   return (
-    <div className="w-screen relative md:-translate-y-5 -translate-y-2 -z-10">
+    <div className="w-screen relative md:-translate-y-5 -translate-y-2 -z-10  ">
       <Image src={image1} alt="Background image 1" className="w-screen" />
       <Image
         src={image2}
         alt="Background image 2"
         className="w-screen top-1/2 absolute"
       />
-      <div className="w-screen md:right-[7%] right-[10%] md:bottom-[30%] bottom-[12%] absolute flex flex-col items-end text-xs md:text-xl">
+      <div className="w-screen md:right-[7%] right-[10%] md:bottom-[30%] bottom-[12%] absolute flex flex-col items-end text-xs md:text-xl  2xl:text-4xl ">
         <p className="italic font-thin">Presenting</p>
         <p className="italic font-bold">Laviathan 2024</p>
         <SlArrowDown className="m-3 mr-9 md:mr-8 md:text-2xl" />
       </div>
-      <div className="md:text-[80px] text-[25px] left-[15%] absolute top-[28%]">
-        <p className="drop-shadow-lg shadow-black font-bold text-robosub-yellow translate-y-3 md:translate-y-6 relative">
+      <div className="md:text-[80px]  text-[25px] left-[15%] absolute top-[28%]  ">
+        <p className="  2xl:text-8xl drop-shadow-lg shadow-black font-bold text-robosub-yellow translate-y-3 md:translate-y-6 relative ">
           UCR
         </p>
-        <p className="font-bold">ROBOSUB</p>
+        <p className=" 2xl:text-9xl 2xl:mt-9 font-bold">ROBOSUB</p>
       </div>
     </div>
   );

--- a/src/components/home/InfoBox.jsx
+++ b/src/components/home/InfoBox.jsx
@@ -3,18 +3,20 @@ import image1 from "@/public/project.webp";
 import image2 from "@/public/vehicle1.webp";
 import Button from "../../components/Button";
 import { AiOutlineDoubleRight } from "react-icons/ai";
-const format = "font-sans font-light md:text-[23px] text-[13px]";
+const format = "font-sans font-light md:text-[23px] text-[13px] 2xl:text-3xl";
 
 const InfoBox = () => {
   return (
     <div className="flex flex-col items-center w-[70%]">
-      <div className="flex flex-col md:flex-row md:justify-between md:mb-[7%] mb-[50%]">
+      <div className="flex flex-col md:flex-row md:justify-between md:mb-[7%] mb-[50%] 2xl:w-[90%]">
         <div className="flex w-full mb-6 md:mb-0 md:w-[55%] flex-col ">
           <div className="flex items-center mb-6 md:mb-[12%]">
             <AiOutlineDoubleRight className=" text-robosub-blue text-2xl md:text-4xl" />
-            <p className="font-bold text-xl md:text-[35px]">Our Project</p>
+            <p className="font-bold text-xl md:text-[35px] 2xl:text-5xl ">
+              Our Project
+            </p>
           </div>
-          <div className="mb-6 md:mb-[10%]">
+          <div className="mb-6 md:mb-[10%] ">
             <p className={format}>
               We are University of California, Riverside&apos;s
             </p>
@@ -26,12 +28,12 @@ const InfoBox = () => {
           </div>
           <Button link="/about" text="LEARN MORE" />
         </div>
-        <div className="object-contain w-full md:w-[45%]">
+        <div className="object-contain w-full md:w-[45%]   ">
           <Image src={image1} alt="Project Image" />
         </div>
       </div>
 
-      <div className="flex flex-col md:flex-row md:justify-between">
+      <div className="flex flex-col md:flex-row md:justify-between 2xl:w-[90%]">
         <div className="object-contain w-full mb-6 md:w-[45%]">
           <Image src={image2} alt="Vehicle Image" />
         </div>
@@ -39,9 +41,11 @@ const InfoBox = () => {
         <div className="flex flex-col items-end w-full md:w-[55%]">
           <div className="flex items-center mb-6 md:mb-[12%]">
             <AiOutlineDoubleRight className=" text-robosub-blue text-2xl md:text-4xl" />
-            <p className="font-bold text-xl md:text-[35px]">Our Vehicle</p>
+            <p className="font-bold text-xl md:text-[35px 2xl:text-5xl">
+              Our Vehicle
+            </p>
           </div>
-          <div className="flex flex-col items-end mb-6 md:mb-[10%]">
+          <div className="flex flex-col items-end mb-6 md:mb-[10%] 2xl:text-4xl">
             <p className={format}>
               Leviathan features five degrees of motion, and is
             </p>

--- a/src/components/home/InfoBox.jsx
+++ b/src/components/home/InfoBox.jsx
@@ -3,7 +3,6 @@ import image1 from "@/public/project.webp";
 import image2 from "@/public/vehicle1.webp";
 import Button from "../../components/Button";
 import { AiOutlineDoubleRight } from "react-icons/ai";
-const format = "font-sans font-light md:text-[23px] text-[13px] 2xl:text-3xl";
 
 const InfoBox = () => {
   return (
@@ -11,20 +10,17 @@ const InfoBox = () => {
       <div className="flex flex-col md:flex-row md:justify-between md:mb-[7%] mb-[50%] 2xl:w-[90%]">
         <div className="flex w-full mb-6 md:mb-0 md:w-[55%] flex-col ">
           <div className="flex items-center mb-6 md:mb-[12%]">
-            <AiOutlineDoubleRight className=" text-robosub-blue text-2xl md:text-4xl" />
+            <AiOutlineDoubleRight className=" text-robosub-blue text-2xl md:text-4xl 2xl:text-5xl" />
             <p className="font-bold text-xl md:text-[35px] 2xl:text-5xl ">
               Our Project
             </p>
           </div>
           <div className="mb-6 md:mb-[10%] ">
-            <p className={format}>
-              We are University of California, Riverside&apos;s
+            <p className="font-sans font-light md:text-[23px] text-[13px] 2xl:text-3xl w-[95%]">
+              We are University of California, Riverside&apos;s competitive
+              autonomoous underwater vehicle project, competing internationally
+              in Robonation&apos;s Robosub Competition.
             </p>
-            <p className={format}>competitive autonomoous underwater vehicle</p>
-            <p className={format}>
-              project, competing internationally in Robonation&apos;s
-            </p>
-            <p className={format}>Robosub Competition.</p>
           </div>
           <Button link="/about" text="LEARN MORE" />
         </div>
@@ -40,23 +36,17 @@ const InfoBox = () => {
 
         <div className="flex flex-col items-end w-full md:w-[55%]">
           <div className="flex items-center mb-6 md:mb-[12%]">
-            <AiOutlineDoubleRight className=" text-robosub-blue text-2xl md:text-4xl" />
-            <p className="font-bold text-xl md:text-[35px 2xl:text-5xl">
+            <AiOutlineDoubleRight className=" text-robosub-blue text-2xl md:text-4xl 2xl:text-5xl" />
+            <p className="font-bold text-xl md:text-[35px] 2xl:text-5xl">
               Our Vehicle
             </p>
           </div>
           <div className="flex flex-col items-end mb-6 md:mb-[10%] 2xl:text-4xl">
-            <p className={format}>
-              Leviathan features five degrees of motion, and is
-            </p>
-            <p className={format}>
-              designed for control efficiency and stability. We
-            </p>
-            <p className={format}>
-              are currently in the construction phase of the
-            </p>
-            <p className={format}>
-              project and are excited to show our results.
+            <p className="font-sans font-light md:text-[23px] text-[13px] 2xl:text-3xl w-[95%] text-end">
+              Leviathan features five degrees of motion, and is designed for
+              control efficiency and stability. We are currently in the
+              construction phase of the project and are excited to show our
+              results.
             </p>
           </div>
           <Button link="/vehicles" text="LEARN MORE" />


### PR DESCRIPTION
<img width="1440" alt="2xl ucr robosub change 27 inch" src="https://github.com/acm-ucr/robosub-website/assets/152819642/4d1c2a0a-2e67-4130-8738-da08096f23e6">
<img width="1440" alt="27inch with the change, but messes with 21 inch" src="https://github.com/acm-ucr/robosub-website/assets/152819642/93879328-f9d9-45e6-a204-08fa2a936837">
<img width="1440" alt="formatting on 27inch" src="https://github.com/acm-ucr/robosub-website/assets/152819642/da8720e6-4776-4c3d-b799-010412480830">
<img width="1440" alt="formatting with 21 inch good:27bad widthchange" src="https://github.com/acm-ucr/robosub-website/assets/152819642/3a0617b2-ae3d-4686-bd6b-20a112d5b81e">



-there was an issue I discovered when working with a 2xl screen. I didn't know if it was in the scope of this request. But the formatting of the website 2xl changes when it's a 21-inch vs 27-inch monitor. a 21-inch which is what I formatted it to works as expected, but on the 27 the upper right photo is unaligned. I tried fixing it to the 27, but it messes with the 21 inch. I added photos. let me know what you think.